### PR TITLE
Remove glog dependency

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,5 +10,4 @@
   <depend package="drivers/aravis" />
   <depend package="drivers/camera_interface" />
   <depend package="image_processing/frame_helper" />
-  <depend package="glog" />
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ rock_library(camera_aravis
 	DEPS_PKGCONFIG camera_interface aravis-0.6 frame_helper
 	)
 
-target_link_libraries(camera_aravis pthread glog)
+target_link_libraries(camera_aravis pthread)
 rock_executable(camera_aravis_test CameraAravisTest.cpp
 	DEPS camera_aravis
 	DEPS_PKGCONFIG opencv camera_interface)

--- a/src/CameraAravis.cpp
+++ b/src/CameraAravis.cpp
@@ -32,9 +32,6 @@ namespace camera
         callbackFcn(NULL),
         errorCallbackFcn(NULL)
     {
-        path = std::string(getenv("AUTOPROJ_CURRENT_ROOT")) + "/drivers/orogen/camera_aravis/scripts";
-        fLS::FLAGS_log_dir = path.c_str();
-        google::InitGoogleLogging("camera_aravis");
         pthread_mutex_init(&buffer_counter_lock, NULL);
     }
 


### PR DESCRIPTION
The orogen component is going to EXCEPTION every time it STOP and it is initialized again. 
The problem is because the method `InitGoogleLogging` was being called twice. 

Since the google logging was only being initialized, but not used, I took it out.  