### PR TITLE
add method to reset timestamp register on the camera

### DIFF
--- a/src/CameraAravis.cpp
+++ b/src/CameraAravis.cpp
@@ -82,6 +82,12 @@ namespace camera
         g_object_unref(tmp_camera);
     }
 
+    void CameraAravis::resetTimestamp()
+    {
+        arv_device_execute_command(arv_camera_get_device(camera), "GevTimestampControlLatchReset");
+        start_time = base::Time::now();
+    }
+
     void CameraAravis::startCapture()
     {
         if(!camera)
@@ -159,7 +165,7 @@ namespace camera
             new_frame.swap(frame);
             new_frame.init(frame.size.width,frame.size.height,8,frame.frame_mode,-1); // ensure right size
             frame.setStatus(base::samples::frame::STATUS_VALID);
-            frame.time = base::Time::fromMicroseconds(arv_buffer_get_timestamp(arv_buffer)*0.001);
+            frame.time = start_time + base::Time::fromMicroseconds(arv_buffer_get_timestamp(arv_buffer)*0.001);
             frame.received_time = base::Time::now();
             //we have to create a new buffer because pointer has changed 
             g_object_unref(arv_buffer);

--- a/src/CameraAravis.cpp
+++ b/src/CameraAravis.cpp
@@ -165,7 +165,7 @@ namespace camera
             new_frame.swap(frame);
             new_frame.init(frame.size.width,frame.size.height,8,frame.frame_mode,-1); // ensure right size
             frame.setStatus(base::samples::frame::STATUS_VALID);
-            frame.time = start_time + base::Time::fromMicroseconds(arv_buffer_get_timestamp(arv_buffer)*0.001);
+            frame.time = start_time + base::Time::fromMicroseconds(arv_buffer_get_timestamp(arv_buffer)/1000);
             frame.received_time = base::Time::now();
             //we have to create a new buffer because pointer has changed 
             g_object_unref(arv_buffer);

--- a/src/CameraAravis.hpp
+++ b/src/CameraAravis.hpp
@@ -25,6 +25,7 @@ namespace camera
 			bool grab(const GrabMode mode = SingleFrame, const int buffer_len=1);
 			void openCamera(std::string camera_name, unsigned packet_size = 1500);
 			static void resetCamera(const std::string& camera_name);
+			void resetTimestamp();
 			ArvPixelFormat getBayerFormat ();
 			bool retrieveFrame(base::samples::frame::Frame &frame,const int timeout=1000);
 			bool isFrameAvailable();
@@ -68,6 +69,7 @@ namespace camera
 			void *callbackData;
 			void *errorCallbackData;
 			pthread_mutex_t buffer_counter_lock;
+            base::Time start_time;
 
 			std::vector<base::samples::frame::Frame> camera_buffer;
 

--- a/src/CameraAravis.hpp
+++ b/src/CameraAravis.hpp
@@ -17,65 +17,65 @@
 
 namespace camera
 {
-	class CameraAravis : public CamInterface
-	{
-		public: 
-			CameraAravis();
-			~CameraAravis();
-			bool grab(const GrabMode mode = SingleFrame, const int buffer_len=1);
-			void openCamera(std::string camera_name, unsigned packet_size = 1500);
-			static void resetCamera(const std::string& camera_name);
-			void resetTimestamp();
-			ArvPixelFormat getBayerFormat ();
-			bool retrieveFrame(base::samples::frame::Frame &frame,const int timeout=1000);
-			bool isFrameAvailable();
-			bool setCallbackFcn(void (*pcallback_function)(const void* p),void *p);
-			bool setErrorCallbackFcn(void (*pcallback_function)(const void* p),void *p);
-			bool isAttribAvail(const int_attrib::CamAttrib attrib);
-			bool isAttribAvail(const double_attrib::CamAttrib attrib);
-			bool isAttribAvail(const str_attrib::CamAttrib attrib);
-			bool isAttribAvail(const enum_attrib::CamAttrib attrib);
-			bool close();
-			std::string doDiagnose();
-			bool setAttrib(const int_attrib::CamAttrib attrib,const int value);
-			int getAttrib(const int_attrib::CamAttrib attrib);
-			bool setAttrib(const enum_attrib::CamAttrib attrib);
-       	    		bool setAttrib(const double_attrib::CamAttrib attrib,const double value);
-			bool isAttribSet(const enum_attrib::CamAttrib attrib);
-			bool setFrameSettings(  const base::samples::frame::frame_size_t size, 
-			const base::samples::frame::frame_mode_t mode,
-			const uint8_t color_depth,
-			const bool resize_frames);
+    class CameraAravis : public CamInterface
+    {
+        public: 
+            CameraAravis();
+            ~CameraAravis();
+            bool grab(const GrabMode mode = SingleFrame, const int buffer_len=1);
+            void openCamera(std::string camera_name, unsigned packet_size = 1500);
+            static void resetCamera(const std::string& camera_name);
+            void resetTimestamp();
+            ArvPixelFormat getBayerFormat ();
+            bool retrieveFrame(base::samples::frame::Frame &frame,const int timeout=1000);
+            bool isFrameAvailable();
+            bool setCallbackFcn(void (*pcallback_function)(const void* p),void *p);
+            bool setErrorCallbackFcn(void (*pcallback_function)(const void* p),void *p);
+            bool isAttribAvail(const int_attrib::CamAttrib attrib);
+            bool isAttribAvail(const double_attrib::CamAttrib attrib);
+            bool isAttribAvail(const str_attrib::CamAttrib attrib);
+            bool isAttribAvail(const enum_attrib::CamAttrib attrib);
+            bool close();
+            std::string doDiagnose();
+            bool setAttrib(const int_attrib::CamAttrib attrib,const int value);
+            int getAttrib(const int_attrib::CamAttrib attrib);
+            bool setAttrib(const enum_attrib::CamAttrib attrib);
+            bool setAttrib(const double_attrib::CamAttrib attrib,const double value);
+            bool isAttribSet(const enum_attrib::CamAttrib attrib);
+            bool setFrameSettings(const base::samples::frame::frame_size_t size, 
+                                  const base::samples::frame::frame_mode_t mode,
+                                  const uint8_t color_depth,
+                                  const bool resize_frames);
 
-		private:
-			std::string getBufferStatusString(ArvBufferStatus status);
-			void printBufferStatus();
-			void startCapture();
-			void stopCapture();
-			void prepareBuffer(const size_t bufferLen);
-			base::samples::frame::frame_mode_t convertArvToFrameMode(ArvPixelFormat format);
+        private:
+            std::string getBufferStatusString(ArvBufferStatus status);
+            void printBufferStatus();
+            void startCapture();
+            void stopCapture();
+            void prepareBuffer(const size_t bufferLen);
+            base::samples::frame::frame_mode_t convertArvToFrameMode(ArvPixelFormat format);
 
-			friend void aravisCameraCallback(ArvStream *stream, CameraAravis *driver);
-			friend void controlLostCallback (CameraAravis *driver);
+            friend void aravisCameraCallback(ArvStream *stream, CameraAravis *driver);
+            friend void controlLostCallback (CameraAravis *driver);
 
-                private:
-                        std::string path;
-			ArvCamera *camera;
-			ArvStream *stream;
-			int current_frame;
-			int buffer_counter;
-			void (*callbackFcn)(const void* p);
-			void (*errorCallbackFcn)(const void* p);
-			void *callbackData;
-			void *errorCallbackData;
-			pthread_mutex_t buffer_counter_lock;
+        private:
+            std::string path;
+            ArvCamera *camera;
+            ArvStream *stream;
+            int current_frame;
+            int buffer_counter;
+            void (*callbackFcn)(const void* p);
+            void (*errorCallbackFcn)(const void* p);
+            void *callbackData;
+            void *errorCallbackData;
+            pthread_mutex_t buffer_counter_lock;
             base::Time start_time;
 
-			std::vector<base::samples::frame::Frame> camera_buffer;
+            std::vector<base::samples::frame::Frame> camera_buffer;
 
-                        unsigned long callback_handler;
-                        unsigned long error_callback_handler;
-	};
+            unsigned long callback_handler;
+            unsigned long error_callback_handler;
+    };
 
 } 
 


### PR DESCRIPTION
it also saves the time when this action occurred, so that time
is added to each of the frame timestamp retrieved by the camera.
It is useful when the device reset its timestamp counter on the
powering on. So it makes the timestamp do no start in the 1970.