### PR TITLE
Find OpenCV with CMake.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,5 +7,6 @@ rock_library(camera_aravis
 target_link_libraries(camera_aravis pthread)
 rock_executable(camera_aravis_test CameraAravisTest.cpp
 	DEPS camera_aravis
-	DEPS_PKGCONFIG opencv camera_interface)
+	DEPS_CMAKE OpenCV
+	DEPS_PKGCONFIG camera_interface)
 TARGET_LINK_LIBRARIES(camera_aravis_test pthread)


### PR DESCRIPTION
OpenCV's name in pkg-config changes with versions, which leads to errors on Ubuntu 20.04.